### PR TITLE
return statement to exit reading loop

### DIFF
--- a/example/websocket/server/async/websocket_server_async.cpp
+++ b/example/websocket/server/async/websocket_server_async.cpp
@@ -126,7 +126,7 @@ public:
             return;
 
         if(ec)
-            fail(ec, "read");
+            return fail(ec, "read");
 
         // Echo the message
         ws_.text(ws_.got_text());


### PR DESCRIPTION
I used this example to start building my WebSocket application, however, I noticed that upon removing the echoing in the `on_read` method, the server repeatedly throws errors without exiting the method. 

You can recreate this problem by replacing `async_write` in the `on_read `method with `do_read` and then cause any error (i.e. client reloads the page).

Adding a return statement here would make debugging for future changes much easier and it wouldn't harm the existing echoing in any way.